### PR TITLE
ドラッグアンドドロップ周りの対応

### DIFF
--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -36,7 +36,7 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
     private var events: MutableList<Event> = mutableListOf()
     /** Event調整ボタンドラッグ開始Y座標(px) */
     private var adjustStartY = 0f
-    /** Event調整ボタンドラッグ開始タップY座標(px) */
+    /** EventをタップしたときのY座標(px) */
     private var adjustStartTapY = 0f
     /** Eventの横幅(dp) */
     private val widthDp = 48

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -47,7 +47,6 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
     private var oldEvent: Event? = null
     /** Eventの時間 */
     private var elapsedTime: TimeParams? = null
-
     init {
         layoutParams = FrameLayout.LayoutParams((widthDp * density).toInt(), FrameLayout.LayoutParams.MATCH_PARENT).apply {
             this.setMargins(density.toInt(), 0, density.toInt(), 0)
@@ -104,7 +103,6 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
                     // Eventの長さを調節するボタンを表示する
                     draggedView.topAdjust.visibility = View.VISIBLE
                     draggedView.bottomAdjust.visibility = View.VISIBLE
-
                     true
                 }
 

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -181,7 +181,7 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
                         putExtra("itemPosition", index)
                         putExtra("event", event.toBundle())
                     }
-                    ViewCompat.startDragAndDrop(view, ClipData.newIntent("event", intent), DragItemShadow(view, adjustStartTapY), view, 0)
+                    ViewCompat.startDragAndDrop(view, ClipData.newIntent("event", intent), EventDragShadowBuilder(view, adjustStartTapY), view, 0)
                     true
                 }
                 // ドラッグ用のイベント追加します
@@ -299,7 +299,10 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
     }
 }
 
-class DragItemShadow(view: View, private val adjustStartTapY: Float) : DragShadowBuilder(view) {
+/**
+ * イベント用のDragShadowBuilder
+ */
+class EventDragShadowBuilder(view: View, private val adjustStartTapY: Float) : DragShadowBuilder(view) {
 
     override fun onProvideShadowMetrics(shadowSize: Point, shadowTouchPoint: Point) {
         val margin = 20

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -5,11 +5,13 @@ import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.databinding.DataBindingUtil
+import android.graphics.Point
 import android.support.v4.view.ViewCompat
 import android.view.DragEvent
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
+import android.view.View.DragShadowBuilder
 import android.widget.FrameLayout
 import jp.kuluna.eventgridview.databinding.ViewEventBinding
 import kotlinx.android.synthetic.main.view_event.view.*
@@ -32,21 +34,25 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
     /** RecyclerViewにおけるこのViewの現在のPosition */
     private var layoutPosition = 0
     private var events: MutableList<Event> = mutableListOf()
-
     /** Event調整ボタンドラッグ開始Y座標(px) */
     private var adjustStartY = 0f
+    /** Event調整ボタンドラッグ開始タップY座標(px) */
+    private var adjustStartTapY = 0f
     /** Eventの横幅(dp) */
     private val widthDp = 48
     /** Eventの最低の高さ */
     private var minEventHeight = convertPxToRoundedDp(90.0F) // 固定値にしてあります
     /** Eventの高さ最大値 */
     private var maxEventHeight = 0
+    /** Eventのトップの最大値 */
+    private var maxEventTop = (TimeParams(24, 0).fromY - 10) * density// 10dp単位なので-10
     /** EventViewの格納用 */
     var eventViews = mutableListOf<View>()
     /** 調整前のEvent */
     private var oldEvent: Event? = null
     /** Eventの時間 */
     private var elapsedTime: TimeParams? = null
+
     init {
         layoutParams = FrameLayout.LayoutParams((widthDp * density).toInt(), FrameLayout.LayoutParams.MATCH_PARENT).apply {
             this.setMargins(density.toInt(), 0, density.toInt(), 0)
@@ -62,9 +68,11 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
                     oldEvent = event
                     val draggedView = (dragEvent.localState as View)
                     // 開始地点がマイナスになった時は0時0分開始にする
-                    var dropStartY = dragEvent.y - (draggedView.height / 2)
+                    var dropStartY = dragEvent.y - adjustStartTapY
                     if (dropStartY < 0) {
                         dropStartY = 0f
+                    } else if (dropStartY >= maxEventTop) {
+                        dropStartY = maxEventTop
                     }
 
                     // ドロップ位置のマージンで再設定
@@ -160,6 +168,12 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
             }
 
             if (draggable) {
+                binding.root.setOnTouchListener { _, touchEvent ->
+                    if (touchEvent.action == MotionEvent.ACTION_DOWN) {
+                        adjustStartTapY = touchEvent.y
+                    }
+                    false
+                }
                 // ロングクリック用のイベント追加します
                 binding.root.setOnLongClickListener { view ->
                     val intent = Intent().apply {
@@ -167,7 +181,7 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
                         putExtra("itemPosition", index)
                         putExtra("event", event.toBundle())
                     }
-                    ViewCompat.startDragAndDrop(view, ClipData.newIntent("event", intent), View.DragShadowBuilder(view), view, 0)
+                    ViewCompat.startDragAndDrop(view, ClipData.newIntent("event", intent), DragItemShadow(view, adjustStartTapY), view, 0)
                     true
                 }
                 // ドラッグ用のイベント追加します
@@ -190,7 +204,7 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
                             val distance = convertPxToRoundedDp((touchEvent.y - adjustStartY))
                             binding.cardView.layoutParams = (binding.cardView.layoutParams as FrameLayout.LayoutParams).apply {
                                 // Eventの長さはminEventHeightより小さくならず、drop直後のHeightより小さい
-                                if ((height - distance) in minEventHeight..maxEventHeight) {
+                                if ((height - distance) in minEventHeight..maxEventHeight && topMargin + distance < maxEventTop) {
                                     topMargin += distance
                                     height -= distance
                                     elapsedTime = TimeParams.from(height.toFloat(), density)
@@ -282,5 +296,16 @@ open class EventColumnView(context: Context, private val draggable: Boolean) : F
         // 10: 最小のドラッグ単位を10dpにする
         val unit = (density * 10).toInt()
         return (px / unit).roundToInt() * unit
+    }
+}
+
+class DragItemShadow(view: View, private val adjustStartTapY: Float) : DragShadowBuilder(view) {
+
+    override fun onProvideShadowMetrics(shadowSize: Point, shadowTouchPoint: Point) {
+        val margin = 20
+        //影の分の領域を含めたサイズを設定
+        shadowSize.set(view.width + margin, view.height + margin)
+        //viewの中央に設定
+        shadowTouchPoint.set(view.width / 2, adjustStartTapY.toInt())
     }
 }

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -16,6 +16,8 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
     var onEventClickListener: OnEventClickListener? = null
     /** Eventをドラッグしたことによる変更イベント */
     var onEventChangedListener: OnEventChangedListener? = null
+    /** 目盛が変わったことによる変更イベント */
+    var onScaleRefreshListener: ((Int) -> Unit)? = null
 
     private var events = emptyList<Event>()
     private var group = emptyList<Pair<Int, List<Event>>>()
@@ -37,7 +39,6 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
                 -1
             }
         }
-    var onScaleRefreshListener: ((Int) -> Unit)? = null
     /** EventViewColumnで生成されたのEventView格納用 */
     private var eventViews = mutableListOf<View>()
     /** ViewHolder全体のEventViewの配列の格納用 */
@@ -95,6 +96,9 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
         }
     }
 
+    /**
+     * 目盛を終了が最も遅いイベントに合わせて更新します
+     */
     private fun scaleRefresh() {
         onScaleRefreshListener?.let {
             it(overTime)

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -37,7 +37,7 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
                 -1
             }
         }
-    var onRplaceListener :((Int) -> Unit)? = null
+    var onScaleRefreshListener: ((Int) -> Unit)? = null
     /** EventViewColumnで生成されたのEventView格納用 */
     private var eventViews = mutableListOf<View>()
     /** ViewHolder全体のEventViewの配列の格納用 */
@@ -60,6 +60,11 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
             if (hideAll) {
                 hideAllAdjustButton()
             }
+            // TODO この辺り処理をちゃんとする
+            val index = events.indexOf(old)
+            events[index].start = new.start
+            events[index].end = new.end
+            scaleRefresh()
         }
         eventViews = holder.view.eventViews
         eventViewGroup.add(eventViews)
@@ -74,9 +79,7 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
         this.group = this.events.groupBy { it.groupId }.toList()
         this.day = day
 
-        onRplaceListener?.let{
-            it(overTime)
-        }
+        scaleRefresh()
         notifyDataSetChanged()
     }
 
@@ -89,6 +92,12 @@ open class EventGridAdapter(val context: Context, private val draggable: Boolean
                 view.topAdjust.visibility = View.INVISIBLE
                 view.bottomAdjust.visibility = View.INVISIBLE
             }
+        }
+    }
+
+    private fun scaleRefresh() {
+        onScaleRefreshListener?.let {
+            it(overTime)
         }
     }
 }

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridView.kt
@@ -16,7 +16,7 @@ class EventGridView : FrameLayout {
         get() = binding.eventGridRecyclerView.adapter as? EventGridAdapter
         set(value) {
             binding.eventGridRecyclerView.adapter = value
-            value?.onRplaceListener = {
+            value?.onScaleRefreshListener = {
                 binding.overTime = it
             }
         }

--- a/lib/src/main/res/layout/view_event.xml
+++ b/lib/src/main/res/layout/view_event.xml
@@ -38,7 +38,8 @@
             <TextView
                 android:id="@+id/text_view"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
+                android:layout_weight="1"
                 android:text="@{event.text}"
                 android:textColor="@{event.textColor}"
                 android:textSize="12sp"


### PR DESCRIPTION
1. ドラッグ開始時に常にバーの中心をつかんでしまう
2. ドラッグ中に画面上または下付近に持って行った時はスクロールしてほしい
3. 両端をつまんでのドラッグのつまみが上側に寄っている