### PR TITLE
EventGridViewからEventとCounterの時間のmin-maxが参照できるように

### DIFF
--- a/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
@@ -24,12 +24,12 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
     /** 基準日 */
     var day = Date()
     /** 最小の時間(単位:時間) */
-    val minTime: Int?
+    val minTime: Int
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val firstStartCal = Calendar.getInstance()
-            firstStartCal.time = firstStart ?: return null
+            firstStartCal.time = firstStart ?: day
 
             return firstStartCal.get(Calendar.HOUR_OF_DAY)
         }
@@ -39,7 +39,7 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val lastEndCal = Calendar.getInstance()
-            lastEndCal.time = lastEnd ?: return null
+            lastEndCal.time = lastEnd ?: day
 
             return if (selectCal.get(Calendar.DATE) != lastEndCal.get(Calendar.DATE)) {
                 // 日跨ぎ有りなら+24時間と、端数を考慮して+1時間

--- a/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
@@ -76,9 +76,8 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
      * カウンタを全てクリアして引数で渡すカウンタに差し替えます。
      * @param counters カウンタリスト
      */
-    fun replace(counters: List<Counter>, day: Date) {
+    fun replace(counters: List<Counter>) {
         this.counters = counters
-        this.day = day
 
         notifyDataSetChanged()
     }
@@ -87,7 +86,7 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
     internal fun setScale(from: Int, to: Int) {
         scaleFrom = from
         scaleTo = to
-        replace(counters, day)
+        replace(counters)
     }
 
     /**

--- a/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.support.v7.widget.RecyclerView
 import android.view.View
 import android.view.ViewGroup
+import org.apache.commons.lang.time.DateUtils
 import java.util.*
 
 /**
@@ -22,7 +23,7 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
     private val lastEnd
         get() = counters.maxBy { it.end }?.end
     /** 基準日 */
-    var day = Date()
+    var day = DateUtils.truncate(Date(), Calendar.DATE)
     /** 最小の時間(単位:時間) */
     val minTime: Int
         get() {
@@ -34,7 +35,7 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
             return firstStartCal.get(Calendar.HOUR_OF_DAY)
         }
     /** 時間の最大値 */
-    val maxTime: Int?
+    val maxTime: Int
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
@@ -87,5 +88,12 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
         scaleFrom = from
         scaleTo = to
         replace(counters, day)
+    }
+
+    /**
+     * カウンタを取得します
+     */
+    fun getCounters(): List<Counter> {
+        return counters
     }
 }

--- a/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/CounterGridAdapter.kt
@@ -15,18 +15,31 @@ open class CounterGridAdapter(private val context: Context) : RecyclerView.Adapt
     var onCounterClickListener: ((Counter) -> Unit)? = null
 
     private var counters = emptyList<Counter>()
+    /** 最初の開始時刻 */
+    private val firstStart
+        get() = counters.minBy { it.start }?.start
     /** 最後の終了時刻 */
     private val lastEnd
         get() = counters.maxBy { it.end }?.end
     /** 基準日 */
     var day = Date()
+    /** 最小の時間(単位:時間) */
+    val minTime: Int?
+        get() {
+            val selectCal = Calendar.getInstance()
+            selectCal.time = day
+            val firstStartCal = Calendar.getInstance()
+            firstStartCal.time = firstStart ?: return null
+
+            return firstStartCal.get(Calendar.HOUR_OF_DAY)
+        }
     /** 時間の最大値 */
-    val maxTime: Int
+    val maxTime: Int?
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val lastEndCal = Calendar.getInstance()
-            lastEndCal.time = lastEnd ?: day
+            lastEndCal.time = lastEnd ?: return null
 
             return if (selectCal.get(Calendar.DATE) != lastEndCal.get(Calendar.DATE)) {
                 // 日跨ぎ有りなら+24時間と、端数を考慮して+1時間

--- a/lib/src/main/java/jp/kuluna/eventgridview/DraggableEventGridListView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/DraggableEventGridListView.kt
@@ -68,11 +68,11 @@ class DraggableEventGridListView : FrameLayout {
             }
         }
 
-    val maxTime: Int?
-        get() = eventGridView.maxTime
+    val maxTimeOfData: Int
+        get() = eventGridView.maxTimeOfData
 
-    val minTime: Int?
-        get() = eventGridView.minTime
+    val minTimeOfData: Int
+        get() = eventGridView.minTimeOfData
 
     /**
      * Eventのカウンタを表示します

--- a/lib/src/main/java/jp/kuluna/eventgridview/DraggableEventGridListView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/DraggableEventGridListView.kt
@@ -68,6 +68,12 @@ class DraggableEventGridListView : FrameLayout {
             }
         }
 
+    val maxTime: Int?
+        get() = eventGridView.maxTime
+
+    val minTime: Int?
+        get() = eventGridView.minTime
+
     /**
      * Eventのカウンタを表示します
      * @param events 集計するEventのリスト

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -45,7 +45,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val firstStartCal = Calendar.getInstance()
-            firstStartCal.time = firstStart ?: return null
+            firstStartCal.time = firstStart ?: day
 
             return firstStartCal.get(Calendar.HOUR_OF_DAY)
         }
@@ -55,7 +55,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val lastEndCal = Calendar.getInstance()
-            lastEndCal.time = lastEnd ?: return null
+            lastEndCal.time = lastEnd ?: day
 
             return if (selectCal.get(Calendar.DATE) != lastEndCal.get(Calendar.DATE)) {
                 // 日跨ぎ有りなら+24時間と、端数を考慮して+1時間

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -40,22 +40,22 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
     private val lastEnd
         get() = events.maxBy { it.end }?.end
     /** 最小の時間(単位:時間) */
-    val minTime: Int
+    val minTime: Int?
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val firstStartCal = Calendar.getInstance()
-            firstStartCal.time = firstStart ?: day
+            firstStartCal.time = firstStart ?: return null
 
             return firstStartCal.get(Calendar.HOUR_OF_DAY)
         }
     /** 最大の時間(単位:時間) */
-    val maxTime: Int
+    val maxTime: Int?
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
             val lastEndCal = Calendar.getInstance()
-            lastEndCal.time = lastEnd ?: day
+            lastEndCal.time = lastEnd ?: return null
 
             return if (selectCal.get(Calendar.DATE) != lastEndCal.get(Calendar.DATE)) {
                 // 日跨ぎ有りなら+24時間と、端数を考慮して+1時間
@@ -149,7 +149,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
      */
     private fun scaleRefresh() {
         onScaleRefreshListener?.let {
-            it(minTime, maxTime)
+            it(minTime ?: 0, maxTime ?: 24)
         }
     }
 }

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -8,6 +8,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import jp.kuluna.eventgridview.databinding.ViewEventBinding
+import org.apache.commons.lang.time.DateUtils
 import java.util.*
 
 /**
@@ -32,7 +33,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
 
     private var events = emptyList<Event>()
     private var group = emptyList<Pair<Int, List<Event>>>()
-    private var day = Date()
+    private var day = DateUtils.truncate(Date(), Calendar.DATE)
     /** 最初の開始時刻 */
     private val firstStart
         get() = events.minBy { it.start }?.start
@@ -40,7 +41,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
     private val lastEnd
         get() = events.maxBy { it.end }?.end
     /** 最小の時間(単位:時間) */
-    val minTime: Int?
+    val minTime: Int
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
@@ -50,7 +51,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
             return firstStartCal.get(Calendar.HOUR_OF_DAY)
         }
     /** 最大の時間(単位:時間) */
-    val maxTime: Int?
+    val maxTime: Int
         get() {
             val selectCal = Calendar.getInstance()
             selectCal.time = day
@@ -149,7 +150,7 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
      */
     private fun scaleRefresh() {
         onScaleRefreshListener?.let {
-            it(minTime ?: 0, maxTime ?: 24)
+            it(minTime, maxTime)
         }
     }
 }

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridView.kt
@@ -98,7 +98,7 @@ class EventGridView : FrameLayout {
         counterGridAdapter.day = date
 
         refreshCounter(events)
-        refreshScale(scaleFrom, scaleTo)
+        setScale(scaleFrom, scaleTo)
     }
 
     /** カウンタを更新します */

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridView.kt
@@ -56,23 +56,21 @@ class EventGridView : FrameLayout {
         }
 
     /** Event・Counterの時間の最小値 */
-    val minTime: Int?
+    val minTimeOfData: Int
         get() {
-            val value = min(adapter?.minTime ?: 48, counterGridAdapter?.minTime ?: 48)
+            val scaleOfMax = resources.getInteger(R.integer.scale_of_max)
+            val value = min(adapter?.minTime ?: scaleOfMax, counterGridAdapter?.minTime
+                    ?: scaleOfMax)
             return when (value) {
-                48 -> null // 空っぽならnull
+                scaleOfMax -> 0 // 空っぽならnull
                 else -> value
             }
         }
 
     /** Event・Counterの時間の最大値 */
-    val maxTime: Int?
+    val maxTimeOfData: Int
         get() {
-            val value = max(adapter?.maxTime ?: 0, counterGridAdapter?.maxTime ?: 0)
-            return when (value) {
-                0 -> null // 空っぽならnull
-                else -> value
-            }
+            return max(adapter?.maxTime ?: 0, counterGridAdapter?.maxTime ?: 0)
         }
 
     /**
@@ -202,10 +200,18 @@ class EventGridView : FrameLayout {
 
         /** from-toの間の時間(単位:時間)をItemsに格納します */
         fun setItemsIn(from: Int, to: Int) {
-            // 引数の値が不正の場合はエラー
-            if (from > 48 || to > 48 || from > to) {
-                throw IllegalArgumentException()
+            val scaleOfMax = context.resources.getInteger(R.integer.scale_of_max)
+            // 引数の値が不正な場合はエラー
+            if (from > to) {
+                throw IllegalArgumentException("The argument `from` must be smaller than the argument `to`.")
             }
+            if (from > scaleOfMax) {
+                throw IllegalArgumentException("The argument `from` must be smaller than $scaleOfMax.")
+            }
+            if (to > scaleOfMax) {
+                throw IllegalArgumentException("The argument `to` must be smaller than $scaleOfMax.")
+            }
+
             val newItems = mutableListOf<Int>()
             for (i in from..to) {
                 newItems.add(i)

--- a/lib/src/main/res/values/values.xml
+++ b/lib/src/main/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="scale_of_max">48</integer>
+</resources>


### PR DESCRIPTION
その他バグの修正
1. adapterをセットし直すと `onCounterClickListener` が空っぽになっていたため再設定するようにした
2. `EventGridView.setItemsIn()` の引数に大きい値を入力するとメモリリークが発生するため不正な引数の場合はExceptionを飛ばすようにした