### PR TITLE
Fix to draw the correct line of the shift-end time in the case it start from next day

### DIFF
--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -128,7 +128,7 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                 Event.CrossOver.FromNextDay -> {
                     val startParams = getParams(event.start, 1)
                     val endParams = getParams(event.end, 1)
-                    startParams.fromY to endParams.fromY
+                    startParams.fromY to endParams.fromY - startParams.fromY
                 }
 
                 Event.CrossOver.FromPreviousDay -> {


### PR DESCRIPTION
In the case that the shift starts from next day, the end timeline of it does not be drawn correctly.
So i fixed that issue.
![device-2020-02-06-130728](https://user-images.githubusercontent.com/60590767/73905162-c2b98100-48e1-11ea-8c6d-894359633b89.png)
