### PR TITLE
Show the correct quantity of the event even in the case of multiple

### DIFF
--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -198,8 +198,6 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                                 cal.add(Calendar.HOUR_OF_DAY, -elapsedTime!!.hour)
                                 cal.add(Calendar.MINUTE, -elapsedTime!!.min)
                                 newEvent.start = cal.time
-                                // サーバのEventデータを書き換えます
-                                onEventChangedListener?.invoke(oldEvent!!, newEvent, false)
 
                                 // 編集表示用のEventを書き換えます
                                 binding.cardView.setOnClickListener(null)
@@ -208,6 +206,8 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                                 }
 
                                 oldEvent = newEvent
+                                event.start = cal.time
+                                onEventChangedListener?.invoke(oldEvent!!, event, false)
                             }
                             true
                         }
@@ -242,8 +242,6 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                                 cal.add(Calendar.HOUR_OF_DAY, elapsedTime!!.hour)
                                 cal.add(Calendar.MINUTE, elapsedTime!!.min)
                                 newEvent.end = cal.time
-                                // サーバのEventデータを書き換えます
-                                onEventChangedListener?.invoke(oldEvent!!, newEvent, false)
 
                                 // 編集表示用のEventを書き換えます
                                 binding.cardView.setOnClickListener(null)
@@ -252,6 +250,8 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                                 }
 
                                 oldEvent = newEvent
+                                event.end = cal.time
+                                onEventChangedListener?.invoke(oldEvent!!, event, false)
                             }
                             true
                         }
@@ -292,7 +292,7 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                         throw ArrayIndexOutOfBoundsException("position: $position events: $events")
                     }
 
-                    val event  = this.events[position]
+                    val event = this.events[position]
                     oldEvent = event
                     var dropStartY = dragEvent.y - adjustStartTapY
                     // EventGridView上部のマージン分下にずれるので補正


### PR DESCRIPTION
### 同じgroupのeventが複数存在する場合に、正しくD&D時の制御が出来ていなかったため、修正

# [動作確認]
### この状態から上のEvent0をしたにずらす
![device-2020-03-11-121303](https://user-images.githubusercontent.com/60590767/76378813-c6816d00-6391-11ea-8972-b56dd8716135.png)

### 正常にeventの数値が更新されている。この状態から下のEvent0を上の方ににずらす
![device-2020-03-11-121319](https://user-images.githubusercontent.com/60590767/76378845-ddc05a80-6391-11ea-9bfa-7bb921750e6d.png)

### 正常にeventの数値が更新されている。
![device-2020-03-11-121338](https://user-images.githubusercontent.com/60590767/76378891-00eb0a00-6392-11ea-9326-80c1c6c268be.png)
