### PR TITLE
Fix to set the oldEvent copy

### DIFF
--- a/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventColumnView.kt
@@ -205,9 +205,9 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                                     onEventClickListener?.invoke(newEvent)
                                 }
 
-                                oldEvent = newEvent
                                 event.start = cal.time
-                                onEventChangedListener?.invoke(oldEvent!!, event, false)
+                                onEventChangedListener?.invoke(oldEvent!!.copy(), newEvent, false)
+                                oldEvent = newEvent
                             }
                             true
                         }
@@ -249,9 +249,9 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                                     onEventClickListener?.invoke(newEvent)
                                 }
 
-                                oldEvent = newEvent
                                 event.end = cal.time
-                                onEventChangedListener?.invoke(oldEvent!!, event, false)
+                                onEventChangedListener?.invoke(oldEvent!!.copy(), newEvent, false)
+                                oldEvent = newEvent
                             }
                             true
                         }
@@ -293,7 +293,6 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                     }
 
                     val event = this.events[position]
-                    oldEvent = event
                     var dropStartY = dragEvent.y - adjustStartTapY
                     // EventGridView上部のマージン分下にずれるので補正
                     dropStartY -= aScale / 2 / density
@@ -320,6 +319,7 @@ open class EventColumnView(context: Context, widthIsMatchParent: Boolean) : Fram
                     endCal.add(Calendar.MILLISECOND, distance.toInt())
                     event.end = endCal.time
 
+                    oldEvent = event.copy()
                     // 変更を通知
                     onEventChangedListener?.invoke(Event.from(intent.getBundleExtra("event")), event, true)
 

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -1,7 +1,6 @@
 package jp.kuluna.eventgridview
 
 import android.content.Context
-import android.util.Log
 import android.view.DragEvent
 import android.view.MotionEvent
 import android.view.View
@@ -109,8 +108,6 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
             if (hideAll) {
                 hideAllAdjustButton()
             }
-            Log.i("test EventGridAdapter", "old : $old")
-            Log.i("test EventGridAdapter", "new : $new")
             onEventChangedListener?.invoke(old, new)
         }
 

--- a/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
+++ b/lib/src/main/java/jp/kuluna/eventgridview/EventGridAdapter.kt
@@ -1,6 +1,7 @@
 package jp.kuluna.eventgridview
 
 import android.content.Context
+import android.util.Log
 import android.view.DragEvent
 import android.view.MotionEvent
 import android.view.View
@@ -108,6 +109,8 @@ open class EventGridAdapter(private val context: Context, private val widthIsMat
             if (hideAll) {
                 hideAllAdjustButton()
             }
+            Log.i("test EventGridAdapter", "old : $old")
+            Log.i("test EventGridAdapter", "new : $new")
             onEventChangedListener?.invoke(old, new)
         }
 


### PR DESCRIPTION
Fix to set the oldEvent copy to the listener for notifying event change

シフトのバーを伸ばした時にシフト時間が更新されない現象直しました。
